### PR TITLE
Off By One Error for BYSETPOS

### DIFF
--- a/functions/parse/recur_functions.php
+++ b/functions/parse/recur_functions.php
@@ -270,6 +270,13 @@ function restrict_bysetpos($times, $freq = '') {
 	sort($times);
 	$new_times = array();
 	foreach ($bysetpos as $setpos) {
+		// For positive values, we need to adjust for
+		// Zero-Based Indexing.
+		$nSetPos = (int)$setpos;
+		if ($nSetPos > 0)
+		{
+			$nSetPos -= 1;
+		}
 		$new_times[] = implode('', array_slice($times, $setpos, 1));
 	}
 	return $new_times;


### PR DESCRIPTION
For recurring events with positive BYSETPOS values, events were showing up off by one.

For example:
Labor Day (as created by Zimbra) had the following RRULE:
FREQ=YEARLY;INTERVAL=1;BYMONTH=9;BYDAY=MO;BYSETPOS=1

BYSETPOS is One-Based Indexing while array_slice(...) uses Zero-Based Indexing.